### PR TITLE
fix: Remove xonsh prefix

### DIFF
--- a/xontrib/cmd_done.py
+++ b/xontrib/cmd_done.py
@@ -124,7 +124,7 @@ def notify_user(hist, readable: str):
     from notifypy import Notify
 
     noti = Notify()
-    noti.title = str(f"xonsh {cmd}")
+    noti.title = str(f"{cmd}")
     noti.message = f'{"Failed" if rtn else "Done"} in {readable}'
     noti.send()
 


### PR DESCRIPTION
It will be great to remove the prefix. It becomes visual trash after 5 minutes of using this great xontrib :)