### PR TITLE
fix(timeout): cast to numeric if user provides custom duration

### DIFF
--- a/xontrib/cmd_done.py
+++ b/xontrib/cmd_done.py
@@ -9,6 +9,9 @@ LONG_DURATION = xsh.env.get("XONTRIB_CD_LONG_DURATION", 5)  # seconds
 TRIGGER_NOTIFICATION = xsh.env.get("XONTRIB_CD_TRIGGER_NOTIFICATION", True)
 NOTIFICATION_APP_NAME = xsh.env.get("XONTRIB_CD_NOTIFICATION_APP_NAME", xsh.env.get("TITLE", "xonsh"))
 
+if isinstance(LONG_DURATION, str):
+    LONG_DURATION = int(LONG_DURATION)
+
 
 def _term_program_mapping() -> dict:
     """The app name doesn't match the $TERMPROGRAM . This is to map equivalent ones in OSX"""


### PR DESCRIPTION
If a user sets a custom duration timeout, since the value gets pulled from the environment and isn't detyped, it comes in as a string and then breaks because of a `>` comparison between a number and a string.

In the long run, probably good to add proper detyping, but for now, this makes things not break.
